### PR TITLE
Fix build for latest OSX toolchain

### DIFF
--- a/src/mtpFilesystemErrors.h
+++ b/src/mtpFilesystemErrors.h
@@ -22,6 +22,8 @@
 #define MTPFILESYSTEMERRORS_H_
 
 #include <stdexcept>
+#include <errno.h>
+#include <string>
 
 // There appears to be a bug in Android 4.0.4 on the Galaxy Nexus (and maybe
 // other Android versions as well) where if you specify a filename greater


### PR DESCRIPTION
This patch fixes jmtpfs on Sierra with the following clang version:

Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.4.0
Thread model: posix
