### PR TITLE
Adding exception handler for MtpErrorCantOpenDevice

### DIFF
--- a/src/jmtpfs.cpp
+++ b/src/jmtpfs.cpp
@@ -453,7 +453,11 @@ int main(int argc, char *argv[])
 			std::cerr << "Requested device not found" << std::endl;
 			return -1;
 		}
-
+		catch(MtpErrorCantOpenDevice&)
+		{
+			std::cerr << "Cannot open requested device" << std::endl;
+			return -1;
+		}
 		context = std::unique_ptr<MtpFuseContext>(new MtpFuseContext(std::move(device), getuid(), getgid()));
 
 	}


### PR DESCRIPTION
MtpErrorCantOpenDevice exception is thrown from MtpDevice::MtpDevice() and this causes crash/coredump. This can be triggered on a Samsung S7 and on a desktop with KDE).
Fix: add exception handler to exit gracefully.